### PR TITLE
fix: remove graphql-tag dependency

### DIFF
--- a/nerdlets/integrations-manager-nerdlet/components/api-key-bar/add-key.js
+++ b/nerdlets/integrations-manager-nerdlet/components/api-key-bar/add-key.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Modal, Button, Popup, Icon, Input } from 'semantic-ui-react';
 import { DataConsumer } from '../../context/data';
-import { NerdGraphMutation } from 'nr1';
+import { NerdGraphMutation, ngql } from 'nr1';
 import { createApiKeyQuery } from '../../context/queries';
-import gql from 'graphql-tag';
 
 export default class AddKey extends React.PureComponent {
   constructor(props) {
@@ -20,7 +19,7 @@ export default class AddKey extends React.PureComponent {
         const { name } = this.state;
         // add key
         NerdGraphMutation.mutate({
-          mutation: gql`
+          mutation: ngql`
             ${createApiKeyQuery(selectedAccount.key, name, userData.id)}
           `
         }).then((value) => {

--- a/nerdlets/integrations-manager-nerdlet/components/api-key-bar/del-key.js
+++ b/nerdlets/integrations-manager-nerdlet/components/api-key-bar/del-key.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Modal, Button, Popup, Icon } from 'semantic-ui-react';
 import { DataConsumer } from '../../context/data';
-import { NerdGraphMutation } from 'nr1';
-import gql from 'graphql-tag';
+import { NerdGraphMutation, ngql } from 'nr1';
 import { deleteApiKeyQuery } from '../../context/queries';
 
 export default class DeleteKey extends React.PureComponent {
@@ -19,7 +18,7 @@ export default class DeleteKey extends React.PureComponent {
       this.setState({ isDeleting: true }, () => {
         // delete key
         NerdGraphMutation.mutate({
-          mutation: gql`
+          mutation: ngql`
             ${deleteApiKeyQuery(selectedApiKey.key)}
           `
         }).then((value) => {

--- a/nerdlets/integrations-manager-nerdlet/context/data.js
+++ b/nerdlets/integrations-manager-nerdlet/context/data.js
@@ -11,11 +11,11 @@ import { ToastContainer, toast } from 'react-toastify';
 import {
   NerdGraphQuery,
   AccountStorageQuery,
-  AccountStorageMutation
+  AccountStorageMutation,
+  ngql
 } from 'nr1';
 import { Icon } from 'semantic-ui-react';
 import pkg from '../../../package.json';
-import gql from 'graphql-tag';
 import {
   accountsQuery,
   catalogNerdpacksQuery,
@@ -183,7 +183,7 @@ export class DataProvider extends Component {
 
   getAccountLicenseKey = (accountId) => {
     NerdGraphQuery.query({
-      query: gql`
+      query: ngql`
         ${accountLicenseKeyQuery(accountId)}
       `
     }).then((value) => {
@@ -227,7 +227,7 @@ export class DataProvider extends Component {
     // check if nerdpack is running from app catalog
     if (nerdpackUUID === '') {
       await NerdGraphQuery.query({
-        query: gql`
+        query: ngql`
           ${catalogNerdpacksQuery}
         `
       }).then((value) => {
@@ -254,7 +254,7 @@ export class DataProvider extends Component {
 
   getUser = () => {
     NerdGraphQuery.query({
-      query: gql`
+      query: ngql`
         ${getUserQuery}
       `
     }).then((value) => {
@@ -272,7 +272,7 @@ export class DataProvider extends Component {
       });
 
       NerdGraphQuery.query({
-        query: gql`
+        query: ngql`
           ${accountsQuery}
         `
       }).then((value) => {
@@ -336,7 +336,7 @@ export class DataProvider extends Component {
 
   getApiKeys = (accountId) => {
     NerdGraphQuery.query({
-      query: gql`
+      query: ngql`
         ${getApiKeysQuery(accountId)}
       `
     }).then((values) => {
@@ -398,7 +398,7 @@ export class DataProvider extends Component {
     }`;
 
     NerdGraphQuery.query({
-      query: gql`
+      query: ngql`
         ${snycQuery}
       `
     }).then(async (value) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1646,11 +1646,6 @@
         "iterall": "^1.2.2"
       }
     },
-    "graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
-    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "ace-builds": "^1.4.12",
     "graphql": "^14.7.0",
-    "graphql-tag": "^2.10.4",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
* we can import ngql from nr1, and use that instead of the graphql-tag
package, so swapping to using that.

### Notes:
* Relates to: #100
* Once this PR is merged, we can close out the snyk PR since this dependency will no longer exist.